### PR TITLE
add optimism testnet

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -18,6 +18,7 @@ import {
   optimism,
   arbitrum,
   goerli,
+  optimismGoerli,
 } from 'wagmi/chains';
 import { publicProvider } from 'wagmi/providers/public';
 
@@ -27,6 +28,7 @@ const { chains, publicClient, webSocketPublicClient } = configureChains(
     polygon,
     optimism,
     arbitrum,
+    optimismGoerli,
     ...(process.env.NEXT_PUBLIC_ENABLE_TESTNETS === 'true' ? [goerli] : []),
   ],
   [publicProvider()]


### PR DESCRIPTION
I've added the network in the providers file, but the button to sign manifesto doesn't show up